### PR TITLE
Monster spawners based on warnings (issue #110)

### DIFF
--- a/examples/mapping/sourcemeter_mapping_example_2_0_monsters.xml
+++ b/examples/mapping/sourcemeter_mapping_example_2_0_monsters.xml
@@ -15,6 +15,9 @@
 				<conversion type="quantization">
 					<parameter name="level0" value="0" />
 					<parameter name="level1" value="1" />
+					<parameter name="level2" value="2" />
+					<parameter name="level3" value="3" />
+					<parameter name="level4" value="4" />
 				</conversion>
 			</conversions>
 		</binding>

--- a/examples/mapping/sourcemeter_mapping_example_2_0_monsters.xml
+++ b/examples/mapping/sourcemeter_mapping_example_2_0_monsters.xml
@@ -1,0 +1,70 @@
+<mapping version="2.0">
+	<resources>
+        <constant id="cellar_character" value="planks"/>
+		<constant id="cellar_external_character" value="wood"/>
+    </resources>
+	<linking source="package" target="ground"/>
+	<linking source="class" target="garden">
+		<binding from="CBO" to="flower-ratio">
+			<conversions>
+				<conversion type="normalize"/>
+			</conversions>
+		</binding>
+		<binding from="WarningMajor" to="monster-count">
+			<conversions>
+				<conversion type="quantization">
+					<parameter name="level0" value="0" />
+					<parameter name="level1" value="1" />
+				</conversion>
+			</conversions>
+		</binding>
+	</linking>
+    <linking source="method" target="floor">
+		<binding from="LLOC" to="height"/>
+		<binding from="NII" to="width"/>
+		<binding from="NOI" to="length"/>
+		<binding from="McCC" to="character">
+			<conversions>
+				<conversion type="quantization">
+					<parameter name="level0" value="glass"/>
+					<parameter name="level1" value="sand"/>
+					<parameter name="level2" value="planks"/>
+					<parameter name="level3" value="stone"/>
+					<parameter name="level4" value="obsidian"/>
+				</conversion>
+			</conversions>
+		</binding>
+		<binding from="McCC" to="external_character">
+			<conversions>
+				<conversion type="quantization">
+					<parameter name="level0" value="metal"/>
+					<parameter name="level1" value="sandstone"/>
+					<parameter name="level2" value="wood"/>
+					<parameter name="level3" value="cobblestone"/>
+					<parameter name="level4" value="obsidian"/>
+				</conversion>
+			</conversions>
+		</binding>
+		<binding from="NUMPAR" to="torches">
+			<conversions>
+				<conversion type="quantization">
+					<parameter name="level0" value="1"/>
+					<parameter name="level1" value="2"/>
+					<parameter name="level2" value="3"/>
+				</conversion>
+			</conversions>
+		</binding>
+	</linking>
+	<linking source="attribute" target="cellar">
+		<binding from="WarningP0" to="torches">
+			<conversions>
+				<conversion type="quantization">
+					<parameter name="level0" value="1"/>
+					<parameter name="level1" value="2"/>
+				</conversion>
+			</conversions>
+		</binding>
+		<binding from="${cellar_character}" to="character"/>
+		<binding from="${cellar_external_character}" to="external_character"/>
+	</linking>
+</mapping>

--- a/examples/mapping/sourcemeter_mapping_example_2_0_monsters.xml
+++ b/examples/mapping/sourcemeter_mapping_example_2_0_monsters.xml
@@ -21,6 +21,17 @@
 				</conversion>
 			</conversions>
 		</binding>
+		<binding from="WarningMajor" to="monster-label">
+			<conversions>
+				<conversion type="quantization">
+					<parameter name="level0" value="No errors" />
+					<parameter name="level1" value="Few major warnings" />
+					<parameter name="level2" value="More major warnings" />
+					<parameter name="level3" value="Lots of major warnings" />
+					<parameter name="level4" value="A large number of major warnings" />
+				</conversion>
+			</conversions>
+		</binding>
 	</linking>
     <linking source="method" target="floor">
 		<binding from="LLOC" to="height"/>

--- a/sources/codemetropolis-toolchain-commons/src/test/java/codemetropolis/toolchain/commons/cmxml/BuildableTest.java
+++ b/sources/codemetropolis-toolchain-commons/src/test/java/codemetropolis/toolchain/commons/cmxml/BuildableTest.java
@@ -1,0 +1,26 @@
+package codemetropolis.toolchain.commons.cmxml;
+
+import codemetropolis.toolchain.commons.cmxml.Buildable.Type;
+import junit.framework.TestCase;
+
+public class BuildableTest extends TestCase {
+
+	Buildable b1, b2, b3;
+	
+	public void setup() {
+		b1 = null;
+		b2 = null;
+		b3 = null;
+	}
+	
+	public void testIsOverlapping() {
+		b1 = new Buildable("test1", "testBuilding1", Type.FLOOR, new Point(0, 0, 0), new Point(2, 2, 2));
+		b2 = new Buildable("test2", "testBuilding2", Type.FLOOR, new Point(1, 1, 1), new Point(2, 2, 2));
+		b3 = new Buildable("test3", "testBuilding3", Type.FLOOR, new Point(-1, -1, -1), new Point(2, 2, 2));
+		
+		assertTrue(b1.isOverlapping(b2));
+		assertTrue(b3.isOverlapping(b1));
+		assertFalse(b2.isOverlapping(b3));
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-commons/src/test/java/codemetropolis/toolchain/commons/cmxml/PointTest.java
+++ b/sources/codemetropolis-toolchain-commons/src/test/java/codemetropolis/toolchain/commons/cmxml/PointTest.java
@@ -1,0 +1,23 @@
+package codemetropolis.toolchain.commons.cmxml;
+
+import junit.framework.TestCase;
+
+public class PointTest extends TestCase {
+
+	Point testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testTranslate() {
+		testObj = new Point(0, 0, 0);
+		
+		Point newPoint = testObj.translate(new Point(1, 2, 3));
+		
+		assertEquals(1, newPoint.getX());
+		assertEquals(2, newPoint.getY());
+		assertEquals(3, newPoint.getZ());
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-commons/src/test/java/codemetropolis/toolchain/commons/util/TimeTest.java
+++ b/sources/codemetropolis-toolchain-commons/src/test/java/codemetropolis/toolchain/commons/util/TimeTest.java
@@ -21,4 +21,38 @@ public class TimeTest extends TestCase {
 		assertEquals(24, testObj.getHours());
 	}
 	
+	public void testGetMinutes() {
+		testObj = new Time(0);
+		assertEquals(0, testObj.getMinutes());
+		
+		testObj = new Time(6999);
+		assertEquals(0, testObj.getMinutes());
+		
+		testObj = new Time(59999);
+		assertEquals(0, testObj.getMinutes());
+		
+		testObj = new Time(60000);
+		assertEquals(1, testObj.getMinutes());
+		
+		testObj = new Time(3600000);
+		assertEquals(0, testObj.getMinutes());
+		
+		testObj = new Time(3730000);
+		assertEquals(2, testObj.getMinutes());
+	}
+	
+	public void testGetSeconds() {
+		testObj = new Time(0);
+		assertEquals(0, testObj.getSeconds());
+		
+		testObj = new Time(3999);
+		assertEquals(3, testObj.getSeconds());
+		
+		testObj = new Time(60000);
+		assertEquals(0, testObj.getSeconds());
+		
+		testObj = new Time(74500);
+		assertEquals(14, testObj.getSeconds());
+	}
+	
 }

--- a/sources/codemetropolis-toolchain-commons/src/test/java/codemetropolis/toolchain/commons/util/TimeTest.java
+++ b/sources/codemetropolis-toolchain-commons/src/test/java/codemetropolis/toolchain/commons/util/TimeTest.java
@@ -1,0 +1,24 @@
+package codemetropolis.toolchain.commons.util;
+
+import junit.framework.TestCase;
+
+public class TimeTest extends TestCase {
+
+	Time testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testGetHours() {
+		testObj = new Time(0);
+		assertEquals(0, testObj.getHours());
+		
+		testObj = new Time(3599999); // 0 hrs 59 mins 59 seconds, 999 milliseconds
+		assertEquals(0, testObj.getHours());
+		
+		testObj = new Time(86400001); // 24 hrs 1 milliseconds
+		assertEquals(24, testObj.getHours());
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-converter/src/test/java/codemetropolis/toolchain/converter/ConverterExecutorArgsTest.java
+++ b/sources/codemetropolis-toolchain-converter/src/test/java/codemetropolis/toolchain/converter/ConverterExecutorArgsTest.java
@@ -6,25 +6,25 @@ import codemetropolis.toolchain.converter.control.ConverterType;
 import junit.framework.TestCase;
 
 public class ConverterExecutorArgsTest extends TestCase {
-	ConverterExecutorArgs result;
+	ConverterExecutorArgs testObj;
 	
 	public void setup () {
-		result = null;
+		testObj = null;
 	}
 	
 	public void testConverterExecutorArgsConstructorNoParams() {
-		result = new ConverterExecutorArgs(ConverterType.SOURCEMETER, "testSource", "testOutput");
-		assertEquals(result.getOutputFile(), "testOutput");
-		assertEquals(result.getSource(), "testSource");
-		assertEquals(result.getType(), ConverterType.SOURCEMETER);
+		testObj = new ConverterExecutorArgs(ConverterType.SOURCEMETER, "testSource", "testOutput");
+		assertEquals("testOutput", testObj.getOutputFile());
+		assertEquals("testSource", testObj.getSource());
+		assertEquals(ConverterType.SOURCEMETER, testObj.getType());
 	}
 	
 	public void testConverterExecutorArgsConstructor() {
-		result = new ConverterExecutorArgs(ConverterType.SONARQUBE, "testSource", "testOutput", new HashMap<String, String>());
-		assertEquals(result.getOutputFile(), "testOutput");
-		assertEquals(result.getSource(), "testSource");
-		assertEquals(result.getType(), ConverterType.SONARQUBE);
-		assertNotNull(result.getParams());
-		assertTrue(result.getParams().isEmpty());
+		testObj = new ConverterExecutorArgs(ConverterType.SONARQUBE, "testSource", "testOutput", new HashMap<String, String>());
+		assertEquals("testOutput", testObj.getOutputFile());
+		assertEquals("testSource", testObj.getSource());
+		assertEquals(ConverterType.SONARQUBE, testObj.getType());
+		assertNotNull(testObj.getParams());
+		assertTrue(testObj.getParams().isEmpty());
 	}
 }

--- a/sources/codemetropolis-toolchain-converter/src/test/java/codemetropolis/toolchain/converter/ConverterExecutorArgsTest.java
+++ b/sources/codemetropolis-toolchain-converter/src/test/java/codemetropolis/toolchain/converter/ConverterExecutorArgsTest.java
@@ -1,0 +1,30 @@
+package codemetropolis.toolchain.converter;
+
+import java.util.HashMap;
+
+import codemetropolis.toolchain.converter.control.ConverterType;
+import junit.framework.TestCase;
+
+public class ConverterExecutorArgsTest extends TestCase {
+	ConverterExecutorArgs result;
+	
+	public void setup () {
+		result = null;
+	}
+	
+	public void testConverterExecutorArgsConstructorNoParams() {
+		result = new ConverterExecutorArgs(ConverterType.SOURCEMETER, "testSource", "testOutput");
+		assertEquals(result.getOutputFile(), "testOutput");
+		assertEquals(result.getSource(), "testSource");
+		assertEquals(result.getType(), ConverterType.SOURCEMETER);
+	}
+	
+	public void testConverterExecutorArgsConstructor() {
+		result = new ConverterExecutorArgs(ConverterType.SONARQUBE, "testSource", "testOutput", new HashMap<String, String>());
+		assertEquals(result.getOutputFile(), "testOutput");
+		assertEquals(result.getSource(), "testSource");
+		assertEquals(result.getType(), ConverterType.SONARQUBE);
+		assertNotNull(result.getParams());
+		assertTrue(result.getParams().isEmpty());
+	}
+}

--- a/sources/codemetropolis-toolchain-converter/src/test/java/codemetropolis/toolchain/converter/control/ConverterLoaderTest.java
+++ b/sources/codemetropolis-toolchain-converter/src/test/java/codemetropolis/toolchain/converter/control/ConverterLoaderTest.java
@@ -1,0 +1,30 @@
+package codemetropolis.toolchain.converter.control;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import codemetropolis.toolchain.commons.cdf.converter.CdfConverter;
+import codemetropolis.toolchain.converter.control.*;
+import codemetropolis.toolchain.converter.sonarqube.SonarQubeConverter;
+import codemetropolis.toolchain.converter.sourcemeter.GraphConverter;
+import junit.framework.TestCase;
+
+public class ConverterLoaderTest extends TestCase {
+	
+	CdfConverter result;
+	
+	
+	public void setup() {
+		result = null;
+	}
+	
+	public void testLoadSourceMeter() {
+		result = ConverterLoader.load(ConverterType.SOURCEMETER, new HashMap<String, String>());
+		assert(result instanceof GraphConverter);
+	}
+	
+	public void testLoadSonarQube() {
+		result = ConverterLoader.load(ConverterType.SONARQUBE, new HashMap<String, String>());
+		assert(result instanceof SonarQubeConverter);
+	}
+}

--- a/sources/codemetropolis-toolchain-converter/src/test/java/codemetropolis/toolchain/converter/sonarqube/SonarMetricTest.java
+++ b/sources/codemetropolis-toolchain-converter/src/test/java/codemetropolis/toolchain/converter/sonarqube/SonarMetricTest.java
@@ -1,0 +1,35 @@
+package codemetropolis.toolchain.converter.sonarqube;
+
+import codemetropolis.toolchain.converter.sonarqube.SonarMetric.MetricType;
+import junit.framework.TestCase;
+
+public class SonarMetricTest extends TestCase {
+	
+	SonarMetric testObj;
+	
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testHashCode() {
+		
+		testObj = new SonarMetric(null, null, null);
+		assertEquals(29791, testObj.hashCode());
+		
+		testObj = new SonarMetric("name1", "value1", null);
+		int value = ((31+"name1".hashCode())*31)*31+"value1".hashCode();
+		assertEquals(value, testObj.hashCode());
+	}
+	
+	public void testEquals() {
+		testObj = new SonarMetric("name1", "value1", MetricType.STRING);
+		
+		assertEquals(true, testObj.equals(testObj));
+		assertEquals(true, testObj.equals(new SonarMetric("name1", "value1", MetricType.STRING)));
+		assertEquals(false, testObj.equals(null));
+		assertEquals(false, testObj.equals(3));
+		assertEquals(false, testObj.equals(new SonarMetric(null, null, null)));
+		assertEquals(false, testObj.equals(new SonarMetric("name1", "value1", null)));
+	}
+}

--- a/sources/codemetropolis-toolchain-mapping/src/main/java/codemetropolis/toolchain/mapping/model/Linking.java
+++ b/sources/codemetropolis-toolchain-mapping/src/main/java/codemetropolis/toolchain/mapping/model/Linking.java
@@ -24,7 +24,7 @@ public class Linking {
     static {
         SUPPORTED_TARGETS.put(Type.FLOOR, new String[]{"width", "height", "length", "character", "external_character", "torches"});
         SUPPORTED_TARGETS.put(Type.CELLAR, new String[]{"width", "height", "length", "character", "external_character", "torches"});
-        SUPPORTED_TARGETS.put(Type.GARDEN, new String[]{"tree-ratio", "mushroom-ratio", "flower-ratio"});
+        SUPPORTED_TARGETS.put(Type.GARDEN, new String[]{"tree-ratio", "mushroom-ratio", "flower-ratio", "monster-count"}); // monster-ratio added by hand
         SUPPORTED_TARGETS.put(Type.GROUND, new String[]{});
     }
 	

--- a/sources/codemetropolis-toolchain-mapping/src/main/java/codemetropolis/toolchain/mapping/model/Linking.java
+++ b/sources/codemetropolis-toolchain-mapping/src/main/java/codemetropolis/toolchain/mapping/model/Linking.java
@@ -24,7 +24,7 @@ public class Linking {
     static {
         SUPPORTED_TARGETS.put(Type.FLOOR, new String[]{"width", "height", "length", "character", "external_character", "torches"});
         SUPPORTED_TARGETS.put(Type.CELLAR, new String[]{"width", "height", "length", "character", "external_character", "torches"});
-        SUPPORTED_TARGETS.put(Type.GARDEN, new String[]{"tree-ratio", "mushroom-ratio", "flower-ratio", "monster-count"}); // monster-ratio added by hand
+        SUPPORTED_TARGETS.put(Type.GARDEN, new String[]{"tree-ratio", "mushroom-ratio", "flower-ratio", "monster-count", "monster-label"});
         SUPPORTED_TARGETS.put(Type.GROUND, new String[]{});
     }
 	

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/MappingExecutorArgsTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/MappingExecutorArgsTest.java
@@ -4,19 +4,19 @@ import junit.framework.TestCase;
 
 public class MappingExecutorArgsTest extends TestCase {
 
-	MappingExecutorArgs result;
+	MappingExecutorArgs testObj;
 	
 	public void setup() {
-		result = null;
+		testObj = null;
 	}
 	
 	public void testMappingExecutorArgs() {
-		result = new MappingExecutorArgs("testCDF", "testOutput", "testMapping", 1.0, true);
-		assertEquals(result.getCdfFile(), "testCDF");
-		assertEquals(result.getOutputFile(), "testOutput");
-		assertEquals(result.getMappingFile(), "testMapping");
-		assertEquals(result.getScale(), 1.0);
-		assertEquals(result.isHierarchyValidationEnabled(), true);
+		testObj = new MappingExecutorArgs("testCDF", "testOutput", "testMapping", 1.0, true);
+		assertEquals("testCDF", testObj.getCdfFile());
+		assertEquals("testOutput", testObj.getOutputFile());
+		assertEquals("testMapping", testObj.getMappingFile());
+		assertEquals(1.0, testObj.getScale());
+		assertEquals(true, testObj.isHierarchyValidationEnabled());
 	}
 	
 }

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/MappingExecutorArgsTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/MappingExecutorArgsTest.java
@@ -1,0 +1,22 @@
+package codemetropolis.toolchain.mapping;
+
+import junit.framework.TestCase;
+
+public class MappingExecutorArgsTest extends TestCase {
+
+	MappingExecutorArgs result;
+	
+	public void setup() {
+		result = null;
+	}
+	
+	public void testMappingExecutorArgs() {
+		result = new MappingExecutorArgs("testCDF", "testOutput", "testMapping", 1.0, true);
+		assertEquals(result.getCdfFile(), "testCDF");
+		assertEquals(result.getOutputFile(), "testOutput");
+		assertEquals(result.getMappingFile(), "testMapping");
+		assertEquals(result.getScale(), 1.0);
+		assertEquals(result.isHierarchyValidationEnabled(), true);
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/control/LimitControllerTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/control/LimitControllerTest.java
@@ -1,0 +1,23 @@
+package codemetropolis.toolchain.mapping.control;
+
+import codemetropolis.toolchain.mapping.model.Limit;
+import junit.framework.TestCase;
+
+public class LimitControllerTest extends TestCase {
+	
+	LimitController testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testAdd() {
+		testObj = new LimitController();
+		
+		testObj.add("name", "from", 2.0);
+		
+		assertNotNull(testObj.getLimit("name", "from"));
+		assertEquals(1, testObj.getLimit("name", "from").getValueSetSize());
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/control/LimitControllerTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/control/LimitControllerTest.java
@@ -1,6 +1,5 @@
 package codemetropolis.toolchain.mapping.control;
 
-import codemetropolis.toolchain.mapping.model.Limit;
 import junit.framework.TestCase;
 
 public class LimitControllerTest extends TestCase {

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/control/MappingControllerTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/control/MappingControllerTest.java
@@ -1,0 +1,69 @@
+package codemetropolis.toolchain.mapping.control;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import codemetropolis.toolchain.commons.cmxml.Buildable;
+import codemetropolis.toolchain.commons.cmxml.Buildable.Type;
+import codemetropolis.toolchain.mapping.model.Mapping;
+import junit.framework.TestCase;
+
+public class MappingControllerTest extends TestCase {
+	
+	MappingController testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+
+	public void testSetProperty() {
+		
+		testObj = new MappingController(new Mapping());
+		
+		Buildable b = new Buildable("id", "name", Type.GARDEN);
+		b.setSizeX(0);
+		b.setSizeY(0);
+		
+		try {
+			Method method = testObj.getClass().getDeclaredMethod("setProperty", Buildable.class, String.class, Object.class, boolean.class);
+			method.setAccessible(true);
+		
+			method.invoke(testObj, b, "width", 3.0, false);
+			
+			assertEquals(3, b.getSizeX());
+			
+			method.invoke(testObj, b, "height", 5.0, false);
+			
+			assertEquals(5, b.getSizeY());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+	public void testFindRoot() {
+		
+		testObj = new MappingController(new Mapping());
+		
+		Collection<Buildable> buildables = new ArrayList<>();
+		
+		Buildable b = new Buildable("id", "name", Type.GARDEN);
+		
+		buildables.add(b);
+		
+		try {
+			Method method = testObj.getClass().getDeclaredMethod("findRoot", Collection.class);
+			method.setAccessible(true);
+			
+			if (b.isRoot()) {
+				assertEquals(b, method.invoke(testObj, buildables));
+			} else {
+				assertNull(method.invoke(testObj, buildables));
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/conversions/ConversionTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/conversions/ConversionTest.java
@@ -41,6 +41,19 @@ public class ConversionTest extends TestCase {
 		assertEquals(42.0, testResult);
 	}
 	
+	public void testToInt() {
+		int testResult;
+		
+		testResult = Conversion.toInt("13");
+		assertEquals(13, testResult);
+		
+		testResult = Conversion.toInt("13.13");
+		assertEquals(13, testResult);
+		
+		testResult = Conversion.toInt(4.9);
+		assertEquals(4, testResult);
+	}
+	
 	public void testAddParameter() {
 		result = new MultiplyConversion();
 		
@@ -51,6 +64,42 @@ public class ConversionTest extends TestCase {
 		assertEquals(1, result.getParameters().length);
 		assertEquals("testKey", result.getParameters()[0].getName());
 		assertEquals("testValue", result.getParameters()[0].getValue());
+	}
+	
+	public void testAddParameters() {
+		result = new MultiplyConversion();
+		
+		assertEquals(0, result.getParameters().length);
+		
+		result.addParameters(new Parameter[] {new Parameter("testKey1", "testValue1")});
+		assertEquals(1, result.getParameters().length);
+		assertEquals("testKey1", result.getParameters()[0].getName());
+		assertEquals("testValue1", result.getParameters()[0].getValue());
+		
+		result.addParameters(new Parameter[] {new Parameter("testKey2", "testValue2"), new Parameter("testKey3", "testValue3")});
+		assertEquals(3, result.getParameters().length);
+		assertEquals("testKey1", result.getParameters()[0].getName());
+		assertEquals("testValue1", result.getParameters()[0].getValue());
+		assertEquals("testKey2", result.getParameters()[1].getName());
+		assertEquals("testValue2", result.getParameters()[1].getValue());
+		assertEquals("testKey3", result.getParameters()[2].getName());
+		assertEquals("testValue3", result.getParameters()[2].getValue());
+	}
+	
+	public void testClearParameters() {
+		result = new MultiplyConversion();
+		
+		result.clearParameters();
+		assertEquals(0, result.getParameters().length);
+		
+		result.addParameter(new Parameter("testKey", "testValue"));
+		result.clearParameters();
+		assertEquals(0, result.getParameters().length);
+		
+		result.addParameter(new Parameter("testKey1", "testValue1"));
+		result.addParameter(new Parameter("testKey2", "testValue2"));
+		result.clearParameters();
+		assertEquals(0, result.getParameters().length);
 	}
 	
 }

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/conversions/ConversionTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/conversions/ConversionTest.java
@@ -1,0 +1,56 @@
+package codemetropolis.toolchain.mapping.conversions;
+
+import codemetropolis.toolchain.mapping.model.Parameter;
+import junit.framework.TestCase;
+
+public class ConversionTest extends TestCase {
+	
+	Conversion result = null;
+	
+	public void setup() {
+		result = null;
+	}
+	
+	public void testCreateFromName() {
+		result = Conversion.createFromName("to_int");
+		assert(result instanceof ToIntConversion);
+		
+		result = Conversion.createFromName("to_double");
+		assert(result instanceof ToDoubleConversion);
+		
+		result = Conversion.createFromName("multiply");
+		assert(result instanceof MultiplyConversion);
+		
+		result = Conversion.createFromName("quantization");
+		assert(result instanceof QuantizationConversion);
+		
+		result = Conversion.createFromName("switch");
+		assert(result instanceof SwitchConversion);
+		
+		result = Conversion.createFromName("abcd");
+		assertNull(result);
+	}
+	
+	public void testToDouble() {
+		double testResult;
+		
+		testResult = Conversion.toDouble("42");
+		assertEquals(42.0, testResult);
+		
+		testResult = Conversion.toDouble((double)42.0);
+		assertEquals(42.0, testResult);
+	}
+	
+	public void testAddParameter() {
+		result = new MultiplyConversion();
+		
+		assertEquals(0, result.getParameters().length);
+		
+		result.addParameter(new Parameter("testKey", "testValue"));
+		
+		assertEquals(1, result.getParameters().length);
+		assertEquals("testKey", result.getParameters()[0].getName());
+		assertEquals("testValue", result.getParameters()[0].getValue());
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/conversions/NormalizeConversionTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/conversions/NormalizeConversionTest.java
@@ -1,0 +1,28 @@
+package codemetropolis.toolchain.mapping.conversions;
+
+import codemetropolis.toolchain.mapping.model.Limit;
+import junit.framework.TestCase;
+
+public class NormalizeConversionTest extends TestCase {
+
+	NormalizeConversion testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testApply() {
+		testObj = new NormalizeConversion();
+		
+		Limit l1 = new Limit();
+		l1.add(42);
+		
+		Limit l2 = new Limit();
+		l2.add(41);
+		l2.add(43);
+		
+		assertEquals(1.0, testObj.apply(24.0, l1));
+		assertEquals(0.5, testObj.apply(42.0, l2));
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/conversions/ToDoubleConversionTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/conversions/ToDoubleConversionTest.java
@@ -1,0 +1,21 @@
+package codemetropolis.toolchain.mapping.conversions;
+
+import codemetropolis.toolchain.mapping.model.Limit;
+import junit.framework.TestCase;
+
+public class ToDoubleConversionTest extends TestCase {
+	
+	ToDoubleConversion testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testApply() {
+		testObj = new ToDoubleConversion();
+		
+		assertEquals(2.0, testObj.apply(2.0, new Limit()));
+		assertEquals(2.0, testObj.apply("2.0", new Limit()));
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/conversions/ToIntConversionTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/conversions/ToIntConversionTest.java
@@ -1,0 +1,21 @@
+package codemetropolis.toolchain.mapping.conversions;
+
+import codemetropolis.toolchain.mapping.model.Limit;
+import junit.framework.TestCase;
+
+public class ToIntConversionTest extends TestCase {
+	
+	ToIntConversion testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testApply() {
+		testObj = new ToIntConversion();
+		
+		assertEquals(3, testObj.apply(3.21, new Limit()));
+		assertEquals(4, testObj.apply("4", new Limit()));
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/model/LimitTest.java
+++ b/sources/codemetropolis-toolchain-mapping/src/test/java/codemetropolis/toolchain/mapping/model/LimitTest.java
@@ -1,0 +1,22 @@
+package codemetropolis.toolchain.mapping.model;
+
+import junit.framework.TestCase;
+
+public class LimitTest extends TestCase {
+	
+	Limit testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testAdd() {
+		testObj = new Limit();
+		
+		testObj.add(3.0);
+		assertEquals(1, testObj.getValueSetSize());
+		assertEquals(3.0, testObj.getMax());
+		assertEquals(3.0, testObj.getMin());
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-placing/src/test/java/codemetropolis/toolchain/placing/layout/LayoutTest.java
+++ b/sources/codemetropolis-toolchain-placing/src/test/java/codemetropolis/toolchain/placing/layout/LayoutTest.java
@@ -1,0 +1,25 @@
+package codemetropolis.toolchain.placing.layout;
+
+import codemetropolis.toolchain.placing.exceptions.NonExistentLayoutException;
+import codemetropolis.toolchain.placing.layout.pack.PackLayout;
+import junit.framework.TestCase;
+
+public class LayoutTest extends TestCase {
+	
+	public void testParse() {
+		
+		try {
+			assert(Layout.parse("PACK") instanceof PackLayout);
+		} catch (NonExistentLayoutException e) {
+			fail();
+		}
+		
+		try {
+			Layout.parse("WRONGTYPE");
+			fail();
+		} catch (NonExistentLayoutException e) {}
+		
+		
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-placing/src/test/java/codemetropolis/toolchain/placing/layout/pack/PackLayoutTest.java
+++ b/sources/codemetropolis-toolchain-placing/src/test/java/codemetropolis/toolchain/placing/layout/pack/PackLayoutTest.java
@@ -1,0 +1,76 @@
+package codemetropolis.toolchain.placing.layout.pack;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import codemetropolis.toolchain.commons.cmxml.Buildable;
+import codemetropolis.toolchain.commons.cmxml.Buildable.Type;
+import codemetropolis.toolchain.commons.cmxml.Point;
+import junit.framework.TestCase;
+
+public class PackLayoutTest extends TestCase {
+	
+	PackLayout testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testGetMaxSizes() {
+		
+		testObj = new PackLayout();
+		
+		Buildable b = new Buildable("id", "name", Type.FLOOR, new Point(), new Point(10,10,10));
+		BuildableWrapper w = new BuildableWrapper(b);
+		
+		Collection<BuildableWrapper> list = new ArrayList<>();
+		
+		try {
+			Method method = testObj.getClass().getDeclaredMethod("getMaxSizes", Collection.class);
+			method.setAccessible(true);
+			
+			Point result = (Point) method.invoke(testObj, list);
+			assertEquals(0, result.getX());
+			assertEquals(0, result.getY());
+			assertEquals(0, result.getZ());
+			
+			list.add(w);
+			result = (Point) method.invoke(testObj, list);
+			
+			assertEquals(10, result.getX());
+			assertEquals(0, result.getY());
+			assertEquals(10, result.getZ());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+	public void testCalculateParentSize() {
+		
+		testObj = new PackLayout();
+		
+		Buildable b = new Buildable("id", "name", Type.FLOOR, new Point(1,1,1), new Point(10,5,2));
+		BuildableWrapper w = new BuildableWrapper(b);
+		
+		Collection<BuildableWrapper> list = new ArrayList<>();
+		list.add(w);
+		
+		//space: 2
+		//minX: 1, maxX: 1+10, minZ: 1, maxZ: 1+2
+		//return: x: 11-1+4, z: 3-1+4
+		try {	
+			Method method = testObj.getClass().getDeclaredMethod("calculateParentSize", Collection.class, int.class);
+			method.setAccessible(true);
+			
+			Point result = (Point) method.invoke(testObj, list, 2);
+			assertEquals(14, result.getX());
+			assertEquals(0, result.getY());
+			assertEquals(6, result.getZ());
+		} catch(Exception e) {
+			e.printStackTrace();
+		}
+		
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-rendering/src/main/java/codemetropolis/toolchain/rendering/model/building/Garden.java
+++ b/sources/codemetropolis-toolchain-rendering/src/main/java/codemetropolis/toolchain/rendering/model/building/Garden.java
@@ -9,6 +9,7 @@ import codemetropolis.toolchain.rendering.model.pattern.RandomPattern;
 import codemetropolis.toolchain.rendering.model.pattern.RepeationPattern;
 import codemetropolis.toolchain.rendering.model.pattern.YSplitPattern;
 import codemetropolis.toolchain.rendering.model.primitive.SignPost;
+import codemetropolis.toolchain.rendering.model.primitive.Spawner;
 import codemetropolis.toolchain.rendering.model.primitive.SolidBox;
 import codemetropolis.toolchain.rendering.util.Orientation;
 
@@ -23,6 +24,7 @@ public class Garden extends Building {
 		prepareBase();
 		prepareDoor();
 		prepareSigns();
+		prepareSpawners();
 	}
 	
 	private void prepareBase( ) {
@@ -143,6 +145,13 @@ public class Garden extends Building {
 		primitives.add(new SignPost(position.getX() + size.getX() - 1, position.getY() + 2, position.getZ(), SignPost.Orientation.NORTHEAST, innerBuildable.getName()));
 		primitives.add(new SignPost(position.getX(), position.getY() + 2, position.getZ() + size.getZ() - 1, SignPost.Orientation.SOUTHWEST, innerBuildable.getName()));
 		primitives.add(new SignPost(position.getX() + size.getX() - 1, position.getY() + 2, position.getZ() + size.getZ() - 1, SignPost.Orientation.SOUTHEAST, innerBuildable.getName()));
+	}
+	
+	private void prepareSpawners( ) {
+		primitives.add(new Spawner(position.getX() + size.getX() / 2, position.getY(), position.getZ() - 3));
+		primitives.add(new Spawner(position.getX() + size.getX() / 2, position.getY(), position.getZ() + size.getZ() + 2));
+		primitives.add(new Spawner(position.getX() - 3, position.getY(), position.getZ() + size.getZ() / 2));
+		primitives.add(new Spawner(position.getX() + size.getX() + 2, position.getY(), position.getZ() + size.getZ() / 2));
 	}
 
 }

--- a/sources/codemetropolis-toolchain-rendering/src/main/java/codemetropolis/toolchain/rendering/model/building/Garden.java
+++ b/sources/codemetropolis-toolchain-rendering/src/main/java/codemetropolis/toolchain/rendering/model/building/Garden.java
@@ -27,6 +27,7 @@ public class Garden extends Building {
 		prepareDoor();
 		prepareSigns();
 		prepareSpawners();
+		prepareSignsForSpawners();
 	}
 	
 	private void prepareBase( ) {
@@ -159,6 +160,25 @@ public class Garden extends Building {
 		if (monster_count > 1) primitives.add(new Spawner(position.getX() + size.getX() / 2, position.getY(), position.getZ() + size.getZ() + 2));
 		if (monster_count > 2) primitives.add(new Spawner(position.getX() - 3, position.getY(), position.getZ() + size.getZ() / 2));
 		if (monster_count > 3) primitives.add(new Spawner(position.getX() + size.getX() + 2, position.getY(), position.getZ() + size.getZ() / 2));
+	}
+	
+	private void prepareSignsForSpawners() {
+		String signName = innerBuildable.hasAttribute("monster-label") ? (innerBuildable.getAttributeValue("monster-label")) : "";
+		
+		switch (monster_count) {
+			case 4:
+				primitives.add(new SignPost(position.getX() + size.getX() + 2, position.getY(), position.getZ() + size.getZ() / 2 + 1, SignPost.Orientation.EAST, signName));
+				primitives.add(new SignPost(position.getX() + size.getX() + 2, position.getY(), position.getZ() + size.getZ() / 2 - 1, SignPost.Orientation.EAST, signName));
+			case 3:
+				primitives.add(new SignPost(position.getX() - 3, position.getY(), position.getZ() + size.getZ() / 2 + 1, SignPost.Orientation.WEST, signName));
+				primitives.add(new SignPost(position.getX() - 3, position.getY(), position.getZ() + size.getZ() / 2 - 1, SignPost.Orientation.WEST, signName));
+			case 2:
+				primitives.add(new SignPost(position.getX() + size.getX() / 2 - 1, position.getY(), position.getZ() + size.getZ() + 2, SignPost.Orientation.SOUTH, signName));
+				primitives.add(new SignPost(position.getX() + size.getX() / 2 + 1, position.getY(), position.getZ() + size.getZ() + 2, SignPost.Orientation.SOUTH, signName));
+			case 1:
+				primitives.add(new SignPost(position.getX() + size.getX() / 2 - 1, position.getY(), position.getZ() - 3, SignPost.Orientation.NORTH, signName));
+				primitives.add(new SignPost(position.getX() + size.getX() / 2 + 1, position.getY(), position.getZ() - 3, SignPost.Orientation.NORTH, signName));
+		}
 	}
 
 }

--- a/sources/codemetropolis-toolchain-rendering/src/main/java/codemetropolis/toolchain/rendering/model/building/Garden.java
+++ b/sources/codemetropolis-toolchain-rendering/src/main/java/codemetropolis/toolchain/rendering/model/building/Garden.java
@@ -14,6 +14,8 @@ import codemetropolis.toolchain.rendering.model.primitive.SolidBox;
 import codemetropolis.toolchain.rendering.util.Orientation;
 
 public class Garden extends Building {
+	
+	int monster_count;
 
 	public Garden(Buildable innerBuildable) throws BuildingTypeMismatchException {
 		super(innerBuildable);
@@ -30,6 +32,11 @@ public class Garden extends Building {
 	private void prepareBase( ) {
 		BasicBlock _fnc = new BasicBlock( "minecraft:fence" );
 		BasicBlock _sns = new BasicBlock( "minecraft:sandstone" );
+		
+		monster_count = innerBuildable.hasAttribute("monster-count") 
+				? Integer.parseInt( innerBuildable.getAttributeValue ("monster-count") )
+				: 0;
+		
 		RandomPattern _flowers = new RandomPattern( new RepeationPattern(  new BasicBlock[][][]{ { { BasicBlock.NonBlock } } } ) );
 		
 		RandomPattern _redOrYellow = new RandomPattern( new RepeationPattern(  new BasicBlock[][][]{ { { new BasicBlock( "minecraft:yellow_flower" ) } } } ) );
@@ -148,10 +155,10 @@ public class Garden extends Building {
 	}
 	
 	private void prepareSpawners( ) {
-		primitives.add(new Spawner(position.getX() + size.getX() / 2, position.getY(), position.getZ() - 3));
-		primitives.add(new Spawner(position.getX() + size.getX() / 2, position.getY(), position.getZ() + size.getZ() + 2));
-		primitives.add(new Spawner(position.getX() - 3, position.getY(), position.getZ() + size.getZ() / 2));
-		primitives.add(new Spawner(position.getX() + size.getX() + 2, position.getY(), position.getZ() + size.getZ() / 2));
+		if (monster_count > 0) primitives.add(new Spawner(position.getX() + size.getX() / 2, position.getY(), position.getZ() - 3));
+		if (monster_count > 1) primitives.add(new Spawner(position.getX() + size.getX() / 2, position.getY(), position.getZ() + size.getZ() + 2));
+		if (monster_count > 2) primitives.add(new Spawner(position.getX() - 3, position.getY(), position.getZ() + size.getZ() / 2));
+		if (monster_count > 3) primitives.add(new Spawner(position.getX() + size.getX() + 2, position.getY(), position.getZ() + size.getZ() / 2));
 	}
 
 }

--- a/sources/codemetropolis-toolchain-rendering/src/main/java/codemetropolis/toolchain/rendering/model/primitive/Spawner.java
+++ b/sources/codemetropolis-toolchain-rendering/src/main/java/codemetropolis/toolchain/rendering/model/primitive/Spawner.java
@@ -1,0 +1,27 @@
+package codemetropolis.toolchain.rendering.model.primitive;
+
+import java.io.File;
+
+import codemetropolis.toolchain.commons.cmxml.Point;
+import codemetropolis.toolchain.rendering.model.BasicBlock;
+
+public class Spawner implements Primitive {
+
+    private Point position;
+
+    public Spawner(int x, int y, int z) {
+        super();
+        this.position = new Point(x, y, z);
+    }
+
+    @Override
+    public int toCSVFile(File directory) {
+        new Boxel(new BasicBlock((short) 52), position).toCSVFile(directory);
+        return 1;
+    }
+    @Override
+    public int getNumberOfBlocks() {
+        return 1;
+    }
+
+}

--- a/sources/codemetropolis-toolchain-rendering/src/test/java/codemetropolis/toolchain/rendering/events/ProgressEventTest.java
+++ b/sources/codemetropolis-toolchain-rendering/src/test/java/codemetropolis/toolchain/rendering/events/ProgressEventTest.java
@@ -1,0 +1,35 @@
+package codemetropolis.toolchain.rendering.events;
+
+import junit.framework.TestCase;
+
+public class ProgressEventTest extends TestCase {
+	
+	ProgressEvent testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testGetPercent() {
+		testObj = new ProgressEvent(new Object(), null, 100, 200, 100);
+		assertEquals(50.0, testObj.getPercent());
+		
+		testObj = new ProgressEvent(new Object(), null, 53, 56, 400);
+		assertEquals(94.64, testObj.getPercent(), 0.01);
+		
+		testObj = new ProgressEvent(new Object(), null, 30, 30, 1000);
+		assertEquals(100.0, testObj.getPercent());
+	}
+	
+	public void testGetTimeLeftInMillis() {
+		testObj = new ProgressEvent(new Object(),  null, 100, 200, 100);
+		assertEquals(100, testObj.getTimeLeftInMillis());
+		
+		testObj = new ProgressEvent(new Object(), null, 53, 56, 400);
+		assertEquals(22, testObj.getTimeLeftInMillis());
+		
+		testObj = new ProgressEvent(new Object(), null, 30, 30, 1000);
+		assertEquals(0, testObj.getTimeLeftInMillis());
+	}
+
+}

--- a/sources/codemetropolis-toolchain-rendering/src/test/java/codemetropolis/toolchain/rendering/model/primitive/BoxelTest.java
+++ b/sources/codemetropolis-toolchain-rendering/src/test/java/codemetropolis/toolchain/rendering/model/primitive/BoxelTest.java
@@ -1,0 +1,24 @@
+package codemetropolis.toolchain.rendering.model.primitive;
+
+import codemetropolis.toolchain.commons.cmxml.Point;
+import codemetropolis.toolchain.rendering.model.BasicBlock;
+import junit.framework.TestCase;
+
+public class BoxelTest extends TestCase {
+	
+	Boxel testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testToCSV() {
+		
+		testObj = new Boxel(new BasicBlock((short) 10, 3), new Point(2,5,6), "info");
+		assertEquals("10;3;2;5;6;info", testObj.toCSV());
+		
+		testObj = new Boxel(new BasicBlock((short) 11, 3), new Point(2,5,6), "");
+		assertEquals("11;3;2;5;6;NULL", testObj.toCSV());
+	}
+	
+}

--- a/sources/codemetropolis-toolchain-rendering/src/test/java/codemetropolis/toolchain/rendering/util/CharacterTest.java
+++ b/sources/codemetropolis-toolchain-rendering/src/test/java/codemetropolis/toolchain/rendering/util/CharacterTest.java
@@ -1,0 +1,61 @@
+package codemetropolis.toolchain.rendering.util;
+
+import junit.framework.TestCase;
+
+public class CharacterTest extends TestCase {
+	
+	Character testObj;
+	
+	public void setup() {
+		testObj = null;
+	}
+	
+	public void testGetBlock() {
+		testObj = Character.STONE;assertEquals("minecraft:stone", testObj.getBlock().getName());	
+		testObj = Character.COBBLESTONE;assertEquals("minecraft:cobblestone", testObj.getBlock().getName());
+		testObj = Character.MOSSY_STONE;assertEquals("minecraft:mossy_cobblestone", testObj.getBlock().getName());
+		testObj = Character.SANDSTONE; assertEquals("minecraft:sandstone", testObj.getBlock().getName());
+		testObj = Character.OBSIDIAN; assertEquals("minecraft:obsidian", testObj.getBlock().getName());
+		testObj = Character.WOOD; assertEquals("minecraft:log", testObj.getBlock().getName());
+		testObj = Character.DARK_WOOD; assertEquals("minecraft:log", testObj.getBlock().getName());
+		testObj = Character.BIRCH_WOOD; assertEquals("minecraft:log", testObj.getBlock().getName());
+		testObj = Character.PLANKS; assertEquals("minecraft:planks", testObj.getBlock().getName());
+		testObj = Character.DARK_PLANKS; assertEquals("minecraft:planks", testObj.getBlock().getName());
+		testObj = Character.METAL; assertEquals("minecraft:iron_block", testObj.getBlock().getName());
+		testObj = Character.DIRT; assertEquals("minecraft:dirt", testObj.getBlock().getName());
+		testObj = Character.SAND; assertEquals("minecraft:sandstone", testObj.getBlock().getName());
+		testObj = Character.RED_SAND; assertEquals("minecraft:sand", testObj.getBlock().getName());
+		testObj = Character.BRICK; assertEquals("minecraft:double_stone_slab", testObj.getBlock().getName());
+		testObj = Character.STONE_BRICK; assertEquals("minecraft:double_stone_slab", testObj.getBlock().getName());
+		testObj = Character.DARK_BRICK; assertEquals("minecraft:double_stone_slab", testObj.getBlock().getName());
+		testObj = Character.GLASS; assertEquals("minecraft:glass", testObj.getBlock().getName());
+		testObj = Character.GOLD; assertEquals("minecraft:gold_block", testObj.getBlock().getName());
+		testObj = Character.DIAMOND; assertEquals("minecraft:diamond_block", testObj.getBlock().getName());
+		testObj = Character.UNDEFINED; assertEquals("minecraft:wool", testObj.getBlock().getName());
+	}
+	
+	public void testGetTopBlock() {
+		testObj = Character.WOOD; assertEquals("minecraft:fence", testObj.getTopBlock().getName());
+		testObj = Character.DARK_WOOD; assertEquals("minecraft:fence", testObj.getTopBlock().getName());
+		testObj = Character.BIRCH_WOOD; assertEquals("minecraft:fence", testObj.getTopBlock().getName());
+		testObj = Character.PLANKS; assertEquals("minecraft:fence", testObj.getTopBlock().getName());
+		testObj = Character.DARK_PLANKS; assertEquals("minecraft:fence", testObj.getTopBlock().getName());
+		
+		testObj = Character.STONE;assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());	
+		testObj = Character.COBBLESTONE;assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.MOSSY_STONE;assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.SANDSTONE; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.OBSIDIAN; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.METAL; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.DIRT; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.SAND; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.RED_SAND; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.BRICK; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.STONE_BRICK; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.DARK_BRICK; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.GLASS; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+		testObj = Character.GOLD; assertEquals(testObj.getBlock().getName(), testObj.getTopBlock().getName());
+	}
+	
+
+}


### PR DESCRIPTION
We have added the ability to create monster spawners in the generated worlds' gardens. These spawners are created based on an attribute named `monster-count` (acceptable integer values range from 0 to 4). The attribute can be added by the mapping tool. We also place signposts near the created spawners. The label of the signposts is determined by the `monster-label` attribute. An example mapping XML file (which is a modified version of `sourcemeter_mapping_example_2_0.xml`) that demonstrates this functionality is also included within our modifications.

We have also implemented unit tests for 30 methods. The GitHub Pages documentation was also updated to reflect the proposed changes - this will be submitted in a separate pull request.

This pull request is submitted as a solution to issue #110.